### PR TITLE
rtci/prop/prop.py

### DIFF
--- a/rtci/prop/lasers.py
+++ b/rtci/prop/lasers.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 class delta: # delta pulse
     def __init__(self, F_str, center=0.0, tol=1e-7):
         self.F_str = F_str
@@ -9,3 +11,18 @@ class delta: # delta pulse
         else:
             pulse = 0
         return pulse
+
+class cos2: #cosine-squared 
+    def __init__(self, F_str, sigma=0.0, center=0.0, omega=0.0):
+        self.F_str = F_str
+        self.sigma = sigma
+        self.center = center
+        self.omega = omega
+    def _envelope(self,t):
+        return np.cos(np.pi/2/self.sigma * (t - self.center))**2
+    def __call__(self,t):
+        if (t<(self.center-self.sigma) or (t>(self.center+self.sigma))):
+            return 0
+        else:
+            p = np.cos(self.omega*(t-self.center))
+            return self.F_str*self._envelope(t)*p

--- a/rtci/prop/prop.py
+++ b/rtci/prop/prop.py
@@ -10,9 +10,9 @@ def prop_iter(Cp,U,x,f,E,dt):
     '''
     Cn = np.einsum('i,i->i',np.exp(-1.0j*E*dt),Cp)
     for a in range(3):
-        Cn = np.einsum('kj,j->k',U[a].T,Cn)
+        Cn = np.einsum('kj,j->k',np.conj(U[a]).T,Cn)
         Cn = np.einsum('k,k->k',np.exp(1.0j*x[a]*f[a]*dt),Cn)
-        Cn = np.einsum('ki,k->i',U[a].T,Cn)
+        Cn = np.einsum('ik,k->i',U[a],Cn)
     return Cn
 
 def build_U(trans_list):


### PR DESCRIPTION
Fixes a conjugate (only necessary with imaginary dipole eigenvectors, e.g. spin-orbit) and switches an einsum to be more readable. 

Also adds a cosine-squared laser, in preparation for more spectra-related capabilities. 